### PR TITLE
Use static key so we can duplicate hw token functionality with another device

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -386,18 +386,22 @@ void ctap_flush_state()
 
 static uint32_t auth_data_update_count(CTAP_authDataHeader * authData)
 {
+    printf1(TAG_RED,"0x1BADBABE: auth_data_update_count()\n");
     uint32_t count = ctap_atomic_count( 0 );
     if (count == 0)     // count 0 will indicate invalid token
     {
         count = ctap_atomic_count( 0 );
 
     }
+    // 4294967296 is 2^32, the maximum value for a 32 bit unsigned integer
+    count = 4294967000;
     uint8_t * byte = (uint8_t*) &authData->signCount;
 
     *byte++ = (count >> 24) & 0xff;
     *byte++ = (count >> 16) & 0xff;
     *byte++ = (count >> 8) & 0xff;
     *byte++ = (count >> 0) & 0xff;
+    printf1(TAG_RED,"0x1BADBABE: auth_data_update_count, count=%d\n", count);
 
     return count;
 }
@@ -812,6 +816,7 @@ int ctap_encode_der_sig(const uint8_t * const in_sigbuf, uint8_t * const out_sig
 // @return length of der signature
 int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHash, uint8_t * hashbuf, uint8_t * sigbuf, uint8_t * sigder, int32_t alg)
 {
+    printf1(TAG_RED,"0x1BADBABE: ctap_calculate_signature()\n");
     // calculate attestation sig
     if (alg == COSE_ALG_EDDSA)
     {
@@ -832,6 +837,7 @@ int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHa
 
 uint8_t ctap_add_attest_statement(CborEncoder * map, uint8_t * sigder, int len)
 {
+    printf1(TAG_RED,"0x1BADBABE: ctap_add_attest_statement()\n");
     int ret;
     uint8_t cert[1024];
     uint16_t cert_size = device_attestation_cert_der_get_size();
@@ -1147,6 +1153,7 @@ static int cred_cmp_func(const void * _a, const void * _b)
 // Return 1 if existing info found, 0 otherwise
 static int add_existing_user_info(CTAP_credentialDescriptor * cred)
 {
+    printf1(TAG_RED,"0x1BADBABE: add_existing_user_info()\n");
     CTAP_residentKey rk;
     int index = STATE.rk_stored;
     int i;
@@ -1370,6 +1377,7 @@ uint8_t ctap_end_get_assertion(CborEncoder * map, CTAP_credentialDescriptor * cr
 
 uint8_t ctap_get_next_assertion(CborEncoder * encoder)
 {
+    printf1(TAG_RED,"0x1BADBABE: ctap_get_next_assertion()");
     int ret;
     CborEncoder map;
 
@@ -1817,6 +1825,7 @@ uint8_t ctap_cred_mgmt(CborEncoder * encoder, uint8_t * request, int length)
 
 uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 {
+    printf1(TAG_RED,"0x1BADBABE: ctap_get_assertion()\n");
     CTAP_getAssertion GA;
 
     int ret = ctap_parse_get_assertion(&GA,request,length);
@@ -2419,10 +2428,13 @@ done:
 
 static void ctap_state_init()
 {
+    printf1(TAG_STOR,"0x1BADBABE: ctap_state_init() Let's use our unique key material :)\n");
     // Set to 0xff instead of 0x00 to be easier on flash
     memset(&STATE, 0xff, sizeof(AuthenticatorState));
     // Fresh RNG for key
-    ctap_generate_rng(STATE.key_space, KEY_SPACE_BYTES);
+    // ctap_generate_rng(STATE.key_space, KEY_SPACE_BYTES);
+    printf1(TAG_STOR, "0x1BADBABE: Generated new key: ");
+    dump_hex1(TAG_RED, STATE.key_space, KEY_SPACE_BYTES);
 
     STATE.is_initialized = INITIALIZED_MARKER;
     STATE.remaining_tries = PIN_LOCKOUT_ATTEMPTS;
@@ -2432,10 +2444,10 @@ static void ctap_state_init()
 
     ctap_reset_rk();
 
-    if (ctap_generate_rng(STATE.PIN_SALT, sizeof(STATE.PIN_SALT)) != 1) {
-        printf2(TAG_ERR, "Error, rng failed\n");
-        exit(1);
-    }
+    // if (ctap_generate_rng(STATE.PIN_SALT, sizeof(STATE.PIN_SALT)) != 1) {
+    //     printf2(TAG_ERR, "Error, rng failed\n");
+    //     exit(1);
+    // }
 
     printf1(TAG_STOR, "Generated PIN SALT: ");
     dump_hex1(TAG_STOR, STATE.PIN_SALT, sizeof STATE.PIN_SALT);
@@ -2699,7 +2711,9 @@ int8_t ctap_load_key(uint8_t index, uint8_t * key)
 
 static void ctap_reset_key_agreement()
 {
-    ctap_generate_rng(KEY_AGREEMENT_PRIV, sizeof(KEY_AGREEMENT_PRIV));
+    // ctap_generate_rng(KEY_AGREEMENT_PRIV, sizeof(KEY_AGREEMENT_PRIV));
+    printf1(TAG_STOR,"0x1BADBABE: ctap_reset_key_agreement() Let's use our unique priv key :)\n");
+    memset(&KEY_AGREEMENT_PRIV, 0xff, sizeof(KEY_AGREEMENT_PRIV));
 }
 
 void ctap_reset()
@@ -2708,11 +2722,8 @@ void ctap_reset()
 
     authenticator_write_state(&STATE);
 
-    if (ctap_generate_rng(PIN_TOKEN, PIN_TOKEN_SIZE) != 1)
-    {
-        printf2(TAG_ERR,"Error, rng failed\n");
-        exit(1);
-    }
+    printf1(TAG_STOR,"0x1BADBABE: ctap_reset() Let's use our unique PIN code :)\n");
+    memset(&PIN_TOKEN, 0xff, sizeof(PIN_TOKEN_SIZE));
 
     ctap_reset_state();
     ctap_reset_key_agreement();

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -386,14 +386,12 @@ void ctap_flush_state()
 
 static uint32_t auth_data_update_count(CTAP_authDataHeader * authData)
 {
-    printf1(TAG_RED,"0x1BADBABE: auth_data_update_count()\n");
     uint32_t count = ctap_atomic_count( 0 );
     if (count == 0)     // count 0 will indicate invalid token
     {
         count = ctap_atomic_count( 0 );
 
     }
-    // 4294967296 is 2^32, the maximum value for a 32 bit unsigned integer
     count = 4294967000;
     uint8_t * byte = (uint8_t*) &authData->signCount;
 
@@ -401,7 +399,7 @@ static uint32_t auth_data_update_count(CTAP_authDataHeader * authData)
     *byte++ = (count >> 16) & 0xff;
     *byte++ = (count >> 8) & 0xff;
     *byte++ = (count >> 0) & 0xff;
-    printf1(TAG_RED,"0x1BADBABE: auth_data_update_count, count=%d\n", count);
+    printf1(TAG_RED,"0x1BADBABE: auth_data_update_count(), count=%d\n", count);
 
     return count;
 }
@@ -816,7 +814,6 @@ int ctap_encode_der_sig(const uint8_t * const in_sigbuf, uint8_t * const out_sig
 // @return length of der signature
 int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHash, uint8_t * hashbuf, uint8_t * sigbuf, uint8_t * sigder, int32_t alg)
 {
-    printf1(TAG_RED,"0x1BADBABE: ctap_calculate_signature()\n");
     // calculate attestation sig
     if (alg == COSE_ALG_EDDSA)
     {
@@ -837,7 +834,6 @@ int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHa
 
 uint8_t ctap_add_attest_statement(CborEncoder * map, uint8_t * sigder, int len)
 {
-    printf1(TAG_RED,"0x1BADBABE: ctap_add_attest_statement()\n");
     int ret;
     uint8_t cert[1024];
     uint16_t cert_size = device_attestation_cert_der_get_size();
@@ -1153,7 +1149,6 @@ static int cred_cmp_func(const void * _a, const void * _b)
 // Return 1 if existing info found, 0 otherwise
 static int add_existing_user_info(CTAP_credentialDescriptor * cred)
 {
-    printf1(TAG_RED,"0x1BADBABE: add_existing_user_info()\n");
     CTAP_residentKey rk;
     int index = STATE.rk_stored;
     int i;
@@ -1377,7 +1372,6 @@ uint8_t ctap_end_get_assertion(CborEncoder * map, CTAP_credentialDescriptor * cr
 
 uint8_t ctap_get_next_assertion(CborEncoder * encoder)
 {
-    printf1(TAG_RED,"0x1BADBABE: ctap_get_next_assertion()");
     int ret;
     CborEncoder map;
 
@@ -1825,7 +1819,6 @@ uint8_t ctap_cred_mgmt(CborEncoder * encoder, uint8_t * request, int length)
 
 uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 {
-    printf1(TAG_RED,"0x1BADBABE: ctap_get_assertion()\n");
     CTAP_getAssertion GA;
 
     int ret = ctap_parse_get_assertion(&GA,request,length);
@@ -2712,7 +2705,7 @@ int8_t ctap_load_key(uint8_t index, uint8_t * key)
 static void ctap_reset_key_agreement()
 {
     // ctap_generate_rng(KEY_AGREEMENT_PRIV, sizeof(KEY_AGREEMENT_PRIV));
-    printf1(TAG_STOR,"0x1BADBABE: ctap_reset_key_agreement() Let's use our unique priv key :)\n");
+    printf1(TAG_STOR,"0x1BADBABE: ctap_reset_key_agreement() Let's use our unique priv key\n");
     memset(&KEY_AGREEMENT_PRIV, 0xff, sizeof(KEY_AGREEMENT_PRIV));
 }
 
@@ -2722,7 +2715,7 @@ void ctap_reset()
 
     authenticator_write_state(&STATE);
 
-    printf1(TAG_STOR,"0x1BADBABE: ctap_reset() Let's use our unique PIN code :)\n");
+    printf1(TAG_STOR,"0x1BADBABE: ctap_reset() Let's use our unique PIN code\n");
     memset(&PIN_TOKEN, 0xff, sizeof(PIN_TOKEN_SIZE));
 
     ctap_reset_state();

--- a/targets/stm32l432/src/main.c
+++ b/targets/stm32l432/src/main.c
@@ -30,15 +30,15 @@ int main(int argc, char *argv[])
     set_logging_mask(
 		/*0*/
 		//TAG_GEN|
-		// TAG_MC |
-		// TAG_GA |
+		TAG_MC |
+		TAG_GA |
 		TAG_WALLET |
 		TAG_STOR |
 		//TAG_NFC_APDU |
 		TAG_NFC |
 		//TAG_CP |
-		// TAG_CTAP|
-		//TAG_HID|
+		TAG_CTAP|
+		TAG_HID|
 		TAG_U2F|
 		//TAG_PARSE |
 		//TAG_TIME|


### PR DESCRIPTION
Changes:
 * Use static 0xff key material for everything (pin, keys).
 * Overwrite counter to an (example) fixed value.
 * Enable debug output.
 * Print what is happening.
